### PR TITLE
Fix yolov3 convert

### DIFF
--- a/convert_tflite.py
+++ b/convert_tflite.py
@@ -61,6 +61,10 @@ def save_tflite():
   model.summary()
 
   converter = tf.lite.TFLiteConverter.from_keras_model(model)
+
+  if tf.__version__ >= '2.2.0':
+    converter.experimental_new_converter = False
+
   if FLAGS.quantize_mode == 'int8':
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
   elif FLAGS.quantize_mode == 'float16':

--- a/convert_tflite.py
+++ b/convert_tflite.py
@@ -58,9 +58,7 @@ def save_tflite():
       model = tf.keras.Model(input_layer, bbox_tensors)
       utils.load_weights(model, FLAGS.weights)
 
-    model = tf.keras.Model(input_layer, bbox_tensors)
-    model.summary()
-    utils.load_weights(model, FLAGS.weights)
+  model.summary()
 
   converter = tf.lite.TFLiteConverter.from_keras_model(model)
   if FLAGS.quantize_mode == 'int8':


### PR DESCRIPTION
I suggest two commits about convert_tflite.py.

1. a80abc4f6424b5eb34d6b51ef07b4913f8aa96a1
  * sinse a2903f7e6fe6e780bdd430e02d6a87f75db69513, yolov3 is overridden by load_wights() for yolov4. 

2. bbecd37d374503529bf46cdb867091532b9b9084
  * in my env (google colab, and TF 2.2.0), following error occurred
`'tf.ResizeNearestNeighbor' op is neither a custom op nor a flex op.`
and it fixed by disabling `experimental_new_converter`.

If looks good to you, prease accept them.
Thanks for your Great implementations!
