### PR TITLE
Fixed int8 quantization and added experimental mixed int8/int16 quantization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin
+checkpoints
+core/__pycache__/
+data/coco
+data/*.weights
+data/*.zip
+lib/
+lib64
+pyvenv.cfg
+share/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoin
 python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416-fp16.tflite --quantize_mode float16
 
 # yolov4 quantize int8
-python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode int8 --dataset ./coco_dataset/coco/val207.txt
+#  - You need to download COCO 2017 dataset using `scripts/get_coco_dataset_2017.sh` and change the absolute file paths in data/dataset/val2017.txt, don't use relative paths
+python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode int8 --dataset ./data/dataset/val2017.txt
 
 # Run demo tflite model
 python detect.py --weights ./checkpoints/yolov4-416.tflite --size 416 --model yolov4 --image ./data/kite.jpg --framework tflite

--- a/README.md
+++ b/README.md
@@ -48,17 +48,30 @@ python save_model.py --weights ./data/yolov4.weights --output ./checkpoints/yolo
 # yolov4
 python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416.tflite
 
+```
+
+### Quantization
+
+```bash
+
 # yolov4 quantize float16
 python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416-fp16.tflite --quantize_mode float16
 
-# yolov4 quantize int8
+# yolov4 quantize int8 (use fp16 for non quantizable ops, fp32 for input/outputs)
 #  - You need to download COCO 2017 dataset using `scripts/get_coco_dataset_2017.sh` and change the absolute file paths in data/dataset/val2017.txt, don't use relative paths
 python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode int8 --dataset ./data/dataset/val2017.txt
+
+# yolov4 quantize mixedint (use int8 for weights, int16 for activations, fp16 for non quantizable ops, fp32 for input/outputs)
+# https://www.tensorflow.org/lite/performance/post_training_quantization#integer_only_16-bit_activations_with_8-bit_weights_experimental
+python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode mixedint --dataset ./data/dataset/val2017.txt
 
 # Run demo tflite model
 python detect.py --weights ./checkpoints/yolov4-416.tflite --size 416 --model yolov4 --image ./data/kite.jpg --framework tflite
 ```
+
 Yolov4 and Yolov4-tiny int8 quantization have some issues. I will try to fix that. You can try Yolov3 and Yolov3-tiny int8 quantization 
+
+
 ### Convert to TensorRT
 ```bash# yolov3
 python save_model.py --weights ./data/yolov3.weights --output ./checkpoints/yolov3.tf --input_size 416 --model yolov3

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ If you want to run yolov3 or yolov3-tiny change ``--model yolov3`` in command
 
 ```bash
 # Save tf model for tflite converting
-python save_model.py --weights ./data/yolov4.weights --output ./checkpoints/yolov4-416 --input_size 416 --model yolov4 --framework tflite
+python save_model.py --weights ./data/yolov4.weights --output ./checkpoints/yolov4-tflite-416 --input_size 416 --model yolov4 --framework tflite
 
 # yolov4
-python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416.tflite
+python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416.tflite
 
 # yolov4 quantize float16
-python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416-fp16.tflite --quantize_mode float16
+python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416-fp16.tflite --quantize_mode float16
 
 # yolov4 quantize int8
 #  - You need to download COCO 2017 dataset using `scripts/get_coco_dataset_2017.sh` and change the absolute file paths in data/dataset/val2017.txt, don't use relative paths
-python convert_tflite.py --weights ./checkpoints/yolov4-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode int8 --dataset ./data/dataset/val2017.txt
+python convert_tflite.py --weights ./checkpoints/yolov4-tflite-416 --output ./checkpoints/yolov4-416-int8.tflite --quantize_mode int8 --dataset ./data/dataset/val2017.txt
 
 # Run demo tflite model
 python detect.py --weights ./checkpoints/yolov4-416.tflite --size 416 --model yolov4 --image ./data/kite.jpg --framework tflite

--- a/convert_tflite.py
+++ b/convert_tflite.py
@@ -11,7 +11,7 @@ from core.config import cfg
 flags.DEFINE_string('weights', './checkpoints/yolov4-416', 'path to weights file')
 flags.DEFINE_string('output', './checkpoints/yolov4-416-fp32.tflite', 'path to output')
 flags.DEFINE_integer('input_size', 416, 'path to output')
-flags.DEFINE_string('quantize_mode', 'float32', 'quantize mode (int8, float16, float32)')
+flags.DEFINE_string('quantize_mode', 'float32', 'quantize mode (int8, float16, float32, mixedint)')
 flags.DEFINE_string('dataset', "/Volumes/Elements/data/coco_dataset/coco/5k.txt", 'path to dataset')
 
 def representative_data_gen():
@@ -42,6 +42,12 @@ def save_tflite():
   elif FLAGS.quantize_mode == 'int8':
     # https://www.tensorflow.org/lite/performance/post_training_quantization#integer_only
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.allow_custom_ops = True
+    converter.representative_dataset = representative_data_gen
+  elif FLAGS.quantize_mode == 'mixedint':
+    # https://www.tensorflow.org/lite/performance/post_training_quantization#integer_only_16-bit_activations_with_8-bit_weights_experimental
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS, tf.lite.OpsSet.EXPERIMENTAL_TFLITE_BUILTINS_ACTIVATIONS_INT16_WEIGHTS_INT8]
     converter.allow_custom_ops = True
     converter.representative_dataset = representative_data_gen
   else:

--- a/convert_tflite.py
+++ b/convert_tflite.py
@@ -15,40 +15,53 @@ flags.DEFINE_string('quantize_mode', 'float32', 'quantize mode (int8, float16, f
 flags.DEFINE_string('dataset', "/Volumes/Elements/data/coco_dataset/coco/5k.txt", 'path to dataset')
 
 def representative_data_gen():
-  fimage = open(FLAGS.dataset).read().split()
-  for input_value in range(10):
-    if os.path.exists(fimage[input_value]):
-      original_image=cv2.imread(fimage[input_value])
+  lines = open(FLAGS.dataset).read().split("\n")
+  line = 0
+  found = 0
+  samples = 10
+  
+  for input_value in range(samples):
+    line += 1
+    file = lines[input_value].split(" ")[0]
+
+    if os.path.exists(file):
+      original_image = cv2.imread(file)
       original_image = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGB)
       image_data = utils.image_preprocess(np.copy(original_image), [FLAGS.input_size, FLAGS.input_size])
       img_in = image_data[np.newaxis, ...].astype(np.float32)
-      print("calibration image {}".format(fimage[input_value]))
+      print("Reading calibration image {}".format(file))
+      found += 1
       yield [img_in]
     else:
+      print("File does not exist %s in %s at line %d" % (file, FLAGS.dataset, line))
       continue
+
+  if found < samples:
+    raise ValueError("Failed to read %d calibration sample images from %s" % (samples, FLAGS.dataset))
+
 
 def save_tflite():
   model = tf.keras.models.load_model(FLAGS.weights)
   model.compile()
   converter = tf.lite.TFLiteConverter.from_keras_model(model)
+  converter.optimizations = [tf.lite.Optimize.DEFAULT]
 
   if FLAGS.quantize_mode == 'float32':
     pass
   elif FLAGS.quantize_mode == 'float16':
-    converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    converter.target_spec.supported_types = [tf.compat.v1.lite.constants.FLOAT16]
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-    converter.allow_custom_ops = True
+    converter.target_spec.supported_types = [tf.float16]
   elif FLAGS.quantize_mode == 'int8':
     # https://www.tensorflow.org/lite/performance/post_training_quantization#integer_only
-    converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    converter.allow_custom_ops = True
+    #converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    #converter.inference_input_type = tf.uint8
+    #converter.inference_output_type = tf.int8
     converter.representative_dataset = representative_data_gen
   elif FLAGS.quantize_mode == 'mixedint':
     # https://www.tensorflow.org/lite/performance/post_training_quantization#integer_only_16-bit_activations_with_8-bit_weights_experimental
-    converter.optimizations = [tf.lite.Optimize.DEFAULT]
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS, tf.lite.OpsSet.EXPERIMENTAL_TFLITE_BUILTINS_ACTIVATIONS_INT16_WEIGHTS_INT8]
-    converter.allow_custom_ops = True
+    #converter.inference_input_type = tf.int16
+    #converter.inference_output_type = tf.int16
     converter.representative_dataset = representative_data_gen
   else:
     raise ValueError("Unkown quantize_mode: " + str(FLAGS.quantize_mode))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.1.1.26
+opencv-python==4.1.2.30
 lxml
 tqdm
 tensorflow==2.3.0rc0


### PR DESCRIPTION
Thanks for providing these examples of working with Yolo v4/v3! 

I managed to fix the int8 quantization by adding a `model.compile()` statement to fix the "optimize global tensors" exception. I could also remove overriding `supported_ops`, by following the examples TensorFlow Lite provides for quantization.

FYI: I'm currently trying to port these models to the K210 / MaixPy MCU, but so far haven't managed to get nncase fully consume the tflite files yet (it doesn't support the `SPLIT` and `DEQUANTIZE` op tflite codes).

*Note:* This only works on the latest `tf-nightly` (2.4.0+). It doesn't work on tensorflow-2.3.0

It doesn't fully quantize currently, since the network uses some non-quantizable ops (EXP). I've not looked further into that yet. 

Best regards,
 Mikael
