### PR TITLE
Updated for Yolo-Tiny

### DIFF
--- a/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/YoloV4Classifier.java
+++ b/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/YoloV4Classifier.java
@@ -178,7 +178,7 @@ public class YoloV4Classifier implements Classifier {
     private static boolean isGPU = true;
 
     // tiny or not
-    private static boolean isTiny = false;
+    private static boolean isTiny = true;
 
     // config yolov4 tiny
     private static final int[] OUTPUT_WIDTH_TINY = new int[]{2535, 2535};


### PR DESCRIPTION
For current android demo's configuration, the "isTiny"  should be true, otherwise, it will prompt error like  issue #301