### PR TITLE
Fixed crucial bug in dataset.py that resulted in wrong label information

### DIFF
--- a/core/dataset.py
+++ b/core/dataset.py
@@ -332,8 +332,8 @@ class Dataset(object):
                 anchors_xywh[:, 0:2] = (
                     np.floor(bbox_xywh_scaled[i, 0:2]).astype(np.int32) + 0.5
                 )
-                anchors_xywh[:, 2:4] = self.anchors[i]
-
+				anchors_xywh[:, 2:4] = self.anchors[i] / self.strides[i]
+				
                 iou_scale = utils.bbox_iou(
                     bbox_xywh_scaled[i][np.newaxis, :], anchors_xywh
                 )


### PR DESCRIPTION
For generating label data for e.g. training the network, the COCO label information are translated into YOLO grid cell labels. Doing this, an IOU score was calculated wrongly, mixing up pixel-scale and grid-scale coordinates in dataset.py. 

This is resulting in very small IOU values for the middle and large grid scale, preventing a training signal for this part of the network. This does may also explain the poorer training performance compared to the original implementation, because 2/3 of the network is not getting a training signal. I fixed the bug simply by dividing the anchor boxes by the strides. Doing this, the IOU is calculated consistently with grid-level coordinates. The resulting target for training the network looks correct now.